### PR TITLE
Add React Router and file download

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.16",
+    "react-router-dom": "^6.23.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,76 +1,46 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import { theme } from './theme';
-import FileUpload from './components/FileUpload/FileUpload';
-import Chat from './components/Chat/Chat';
-import PdfViewer from './components/PdfViewer/PdfViewer';
 import GlobalStyle from './GlobalStyle';
-import { pageNavigationPlugin } from "@react-pdf-viewer/page-navigation";
-import { AppContainer, Title, Subtitle, ContentContainer, ContentPanel, FileUploadContainer } from './App.styles';
-import { initAuth } from './services/api'; // Add this import
+import { AppContainer } from './App.styles';
+import UploadPage from './pages/UploadPage';
+import ChatPage from './pages/ChatPage';
+import { initAuth } from './services/api';
 
+interface FileInfo {
+  url: string;
+  name: string;
+}
 
 const App: React.FC = () => {
-  const [chatId, setChatId] = useState<string | null>(null);
-  const [fileUrl, setFileUrl] = useState<string | null>(null);
-  const [fileName, setFileName] = useState<string>("");
-
+  const [files, setFiles] = useState<Record<string, FileInfo>>({});
   const isAuthInitialized = useRef(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!isAuthInitialized.current) {
       isAuthInitialized.current = true;
-      // Call /auth/init on app mount
-      console.log("Initializing authentication...");
       initAuth();
     }
   }, []);
 
-  const handleFileUploaded = (chatId: string, newFileUrl: string, newFileName: string) => {
-    setChatId(chatId);
-    setFileUrl(newFileUrl);
-    setFileName(newFileName);
-  };
-
-  const pageNavigationPluginInstance = pageNavigationPlugin();
-  const {
-    jumpToPage
-  } = pageNavigationPluginInstance;
-
-  const handleBadgeClick = (pageRef: number) => {
-    if (jumpToPage) {
-      jumpToPage(pageRef);
-    }
+  const handleFileUploaded = (chatId: string, fileUrl: string, fileName: string) => {
+    setFiles(prev => ({ ...prev, [chatId]: { url: fileUrl, name: fileName } }));
+    navigate(`/chat/${chatId}`);
   };
 
   return (
-      <ThemeProvider theme={theme}>
-        <GlobalStyle/>
-        <AppContainer>
-          {!chatId ? (
-              <FileUploadContainer>
-                <Title>Doc Chat</Title>
-                <Subtitle>Upload a PDF and chat with its contents</Subtitle>
-                <FileUpload onFileUploaded={handleFileUploaded}/>
-              </FileUploadContainer>
-          ) : (
-              <ContentContainer>
-                <ContentPanel>
-                  {fileUrl && <PdfViewer fileUrl={fileUrl}
-                                         fileName={fileName}
-                                         pageNavigationPluginInstance={pageNavigationPluginInstance}/>}
-                </ContentPanel>
-                <ContentPanel>
-                  <Chat
-                      chatId={chatId}
-                      onBadgeClick={handleBadgeClick}
-                  />
-                </ContentPanel>
-              </ContentContainer>
-          )}
-        </AppContainer>
-      </ThemeProvider>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <AppContainer>
+        <Routes>
+          <Route path="/" element={<UploadPage onFileUploaded={handleFileUploaded} />} />
+          <Route path="/chat/:chatId" element={<ChatPage files={files} />} />
+        </Routes>
+      </AppContainer>
+    </ThemeProvider>
   );
-}
+};
 
 export default App;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
@@ -9,7 +10,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { pageNavigationPlugin } from '@react-pdf-viewer/page-navigation';
+import PdfViewer from '../components/PdfViewer/PdfViewer';
+import Chat from '../components/Chat/Chat';
+import { ContentContainer, ContentPanel } from '../App.styles';
+import { downloadFile } from '../services/api';
+
+interface FileInfo {
+  url: string;
+  name: string;
+}
+
+interface ChatPageProps {
+  files: Record<string, FileInfo>;
+}
+
+const ChatPage: React.FC<ChatPageProps> = ({ files }) => {
+  const { chatId = '' } = useParams<{ chatId: string }>();
+  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string>('');
+
+  const pageNavigationPluginInstance = pageNavigationPlugin();
+  const { jumpToPage } = pageNavigationPluginInstance;
+
+  useEffect(() => {
+    if (!chatId) return;
+    const info = files[chatId];
+    if (info) {
+      setFileUrl(info.url);
+      setFileName(info.name);
+    } else {
+      downloadFile(chatId)
+        .then(({ url, fileName }) => {
+          setFileUrl(url);
+          setFileName(fileName);
+        })
+        .catch(err => console.error('Error downloading file:', err));
+    }
+  }, [chatId, files]);
+
+  const handleBadgeClick = (pageRef: number) => {
+    if (jumpToPage) {
+      jumpToPage(pageRef);
+    }
+  };
+
+  if (!chatId) return null;
+
+  return (
+    <ContentContainer>
+      <ContentPanel>
+        {fileUrl && (
+          <PdfViewer
+            fileUrl={fileUrl}
+            fileName={fileName}
+            pageNavigationPluginInstance={pageNavigationPluginInstance}
+          />
+        )}
+      </ContentPanel>
+      <ContentPanel>
+        <Chat chatId={chatId} onBadgeClick={handleBadgeClick} />
+      </ContentPanel>
+    </ContentContainer>
+  );
+};
+
+export default ChatPage;

--- a/client/src/pages/UploadPage.tsx
+++ b/client/src/pages/UploadPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import FileUpload from '../components/FileUpload/FileUpload';
+import { FileUploadContainer, Title, Subtitle } from '../App.styles';
+
+interface UploadPageProps {
+  onFileUploaded: (chatId: string, fileUrl: string, fileName: string) => void;
+}
+
+const UploadPage: React.FC<UploadPageProps> = ({ onFileUploaded }) => (
+  <FileUploadContainer>
+    <Title>Doc Chat</Title>
+    <Subtitle>Upload a PDF and chat with its contents</Subtitle>
+    <FileUpload onFileUploaded={onFileUploaded} />
+  </FileUploadContainer>
+);
+
+export default UploadPage;

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -35,3 +35,16 @@ export const initAuth = async (): Promise<void> => {
     withCredentials: true,
   });
 };
+
+export const downloadFile = async (chatId: string): Promise<{ url: string; fileName: string }> => {
+  const response = await axios.get(`${API_URL}/chats/${chatId}/file`, {
+    responseType: 'blob',
+    withCredentials: true,
+  });
+
+  const disposition = response.headers['content-disposition'] || '';
+  const fileNameMatch = disposition.match(/filename="?([^";]+)"?/);
+  const fileName = fileNameMatch ? fileNameMatch[1] : `document.pdf`;
+  const url = URL.createObjectURL(response.data);
+  return { url, fileName };
+};


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- add browser router entry point
- refactor `App` with routing
- implement `UploadPage` and `ChatPage`
- allow downloading files from the server when needed

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684699331b808324a27e32065a0ae26e