### PR TITLE
Fix React Router future flag warning

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,7 +10,7 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter future={{ v7_relativeSplatPath: true }}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- address React Router warning about v7_relativeSplatPath

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'doc_chat')*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a09c478c83249cfb9a7ccfbe3a65