### PR TITLE
Enhance sidebar UI and interactions

### DIFF
--- a/client/src/components/FileUpload/FileUpload.styles.tsx
+++ b/client/src/components/FileUpload/FileUpload.styles.tsx
@@ -7,6 +7,7 @@ export const UploadContainer = styled.div`
 export const UploadButton = styled.button`
     background-color: ${props => props.theme.colors.primaryA0};
     color: ${props => props.theme.colors.white};
+    width: 100%;
     padding: 10px 15px;
     border: none;
     border-radius: 4px;

--- a/client/src/components/FileUpload/FileUpload.tsx
+++ b/client/src/components/FileUpload/FileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { uploadFile } from '../../services/api';
 import {
   UploadContainer,
@@ -11,8 +11,11 @@ interface FileUploadProps {
   onFileUploaded: (chatId: string, fileUrl: string, fileName: string) => void;
 }
 
+import { SidebarContext } from '../Sidebar/SidebarContext';
+
 const FileUpload: React.FC<FileUploadProps> = ({ onFileUploaded }) => {
   const [isUploading, setIsUploading] = useState(false);
+  const { close } = useContext(SidebarContext);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const handleButtonClick = () => {
@@ -28,6 +31,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onFileUploaded }) => {
       const response = await uploadFile(file);
       const fileUrl = URL.createObjectURL(file);
       onFileUploaded(response.chatId, fileUrl, file.name);
+      close();
     } catch (error) {
       console.error('Error uploading file:', error);
     } finally {

--- a/client/src/components/PdfViewer/PdfViewer.styles.tsx
+++ b/client/src/components/PdfViewer/PdfViewer.styles.tsx
@@ -17,7 +17,7 @@ export const FileNameContainer = styled.div`
     font-family: ${props => props.theme.fonts.body}
     font-size: 16px;
     font-weight: 700;
-    margin-left: 30px;
+    margin-left: 35px;
     padding-left: 8px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/client/src/components/Sidebar/Sidebar.styles.tsx
+++ b/client/src/components/Sidebar/Sidebar.styles.tsx
@@ -10,13 +10,13 @@ export const SidebarContainer = styled.div<{ $open: boolean }>`
   transform: translateX(${props => (props.$open ? '0' : '-100%')});
   transition: transform 0.3s ease-in-out;
   z-index: 999;
-  overflow-y: auto;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   padding: 20px;
 `;
 
-export const ToggleButton = styled.button`
+export const ToggleButton = styled.button<{ $open: boolean }>`
   position: fixed;
   top: 6px;
   left: 5px;
@@ -28,6 +28,7 @@ export const ToggleButton = styled.button`
   width: 25px;
   height: 25px;
   cursor: pointer;
+  display: ${props => (props.$open ? 'none' : 'block')};
 `;
 
 export const DocumentList = styled.ul`
@@ -35,7 +36,6 @@ export const DocumentList = styled.ul`
   padding: 0;
   margin: 0;
   flex: 1;
-  overflow-y: auto;
 `;
 
 export const DocumentItem = styled.li`
@@ -53,4 +53,30 @@ export const Timestamp = styled.span`
   display: block;
   font-size: 12px;
   color: ${props => props.theme.colors.grey500};
+`;
+
+export const SidebarHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+`;
+
+export const HeaderIcon = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+export const CloseButton = styled.button`
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+`;
+
+export const DocumentTitle = styled.span`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/client/src/components/Sidebar/Sidebar.styles.tsx
+++ b/client/src/components/Sidebar/Sidebar.styles.tsx
@@ -1,82 +1,80 @@
 import styled from 'styled-components';
 
 export const SidebarContainer = styled.div<{ $open: boolean }>`
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 400px;
-  background-color: ${props => props.theme.colors.grey100};
-  transform: translateX(${props => (props.$open ? '0' : '-100%')});
-  transition: transform 0.3s ease-in-out;
-  z-index: 999;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 400px;
+    background-color: ${props => props.theme.colors.grey50};
+    transform: translateX(${props => (props.$open ? '0' : '-100%')});
+    transition: transform 0.3s ease-in-out;
+    z-index: 999;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
 `;
 
 export const ToggleButton = styled.button<{ $open: boolean }>`
-  position: fixed;
-  top: 6px;
-  left: 5px;
-  z-index: 1000;
-  background: ${props => props.theme.colors.primaryA0};
-  color: ${props => props.theme.colors.white};
-  border: none;
-  border-radius: 4px;
-  width: 25px;
-  height: 25px;
-  cursor: pointer;
-  display: ${props => (props.$open ? 'none' : 'block')};
+    position: fixed;
+    top: 6px;
+    left: 10px;
+    z-index: 1000;
+    background: ${props => props.theme.colors.primaryA0};
+    color: ${props => props.theme.colors.white};
+    border: none;
+    border-radius: 4px;
+    width: 25px;
+    height: 25px;
+    cursor: pointer;
+    display: ${props => (props.$open ? 'none' : 'block')};
 `;
 
 export const DocumentList = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  flex: 1;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
 `;
 
 export const DocumentItem = styled.li`
-  padding: 8px 4px;
-  cursor: pointer;
-  border-bottom: 1px solid ${props => props.theme.colors.grey300};
-  text-align: left;
+    padding: 8px 4px;
+    cursor: pointer;
+    border-bottom: 1px solid ${props => props.theme.colors.grey300};
+    text-align: left;
 
-  &:hover {
-    background-color: ${props => props.theme.colors.grey200};
-  }
-`;
-
-export const Timestamp = styled.span`
-  display: block;
-  font-size: 12px;
-  color: ${props => props.theme.colors.grey500};
+    &:hover {
+        background-color: ${props => props.theme.colors.grey200};
+    }
 `;
 
 export const SidebarHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 20px;
-`;
-
-export const HeaderIcon = styled.img`
-  width: 24px;
-  height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 40px;
 `;
 
 export const CloseButton = styled.button`
-  background: none;
-  border: none;
-  font-size: 20px;
-  cursor: pointer;
+    background: none;
+    border: none;
+    color: ${props => props.theme.colors.primaryA0};
+    font-size: 20px;
+    cursor: pointer;
 `;
 
 export const DocumentTitle = styled.span`
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: ${props => props.theme.colors.textDark};
+`;
+
+export const Timestamp = styled.span`
+    margin-top: 3px;
+    display: block;
+    font-size: 12px;
+    color: ${props => props.theme.colors.grey800};
 `;

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -11,11 +11,9 @@ import {
   DocumentItem,
   Timestamp,
   SidebarHeader,
-  HeaderIcon,
   CloseButton,
   DocumentTitle,
 } from './Sidebar.styles';
-import logo from '../../logo.svg';
 
 interface SidebarProps {
   onFileReady: (chatId: string, fileUrl: string, fileName: string) => void;
@@ -44,7 +42,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e: MouseEvent) => {
-      if (sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) {
+      if (sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) { // close sidebar if clicked outside
         close();
       }
     };
@@ -68,7 +66,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
       <ToggleButton onClick={toggle} $open={isOpen}>☰</ToggleButton>
       <SidebarContainer ref={sidebarRef} $open={isOpen}>
         <SidebarHeader>
-          <HeaderIcon src={logo} alt="logo" />
           <CloseButton onClick={close}>X</CloseButton>
         </SidebarHeader>
         <FileUpload onFileUploaded={(id, url, name) => {
@@ -82,7 +79,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
           {documents.map(doc => (
             <DocumentItem key={doc.chatId} onClick={() => handleDocumentClick(doc)}>
               <DocumentTitle title={doc.fileName}>{doc.fileName}</DocumentTitle>
-              <Timestamp>{new Date(doc.createdAt).toLocaleString()}</Timestamp>
+              <Timestamp>{new Date(doc.createdAt).toLocaleDateString()}</Timestamp>
             </DocumentItem>
           ))}
         </DocumentList>

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -4,7 +4,18 @@ import FileUpload from '../FileUpload/FileUpload';
 import { downloadFile, getChats } from '../../services/api';
 import { ChatInfo } from '../../types/apiTypes';
 import { SidebarContext } from './SidebarContext';
-import { SidebarContainer, ToggleButton, DocumentList, DocumentItem, Timestamp } from './Sidebar.styles';
+import {
+  SidebarContainer,
+  ToggleButton,
+  DocumentList,
+  DocumentItem,
+  Timestamp,
+  SidebarHeader,
+  HeaderIcon,
+  CloseButton,
+  DocumentTitle,
+} from './Sidebar.styles';
+import logo from '../../logo.svg';
 
 interface SidebarProps {
   onFileReady: (chatId: string, fileUrl: string, fileName: string) => void;
@@ -12,6 +23,7 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
   const { isOpen, toggle, close } = useContext(SidebarContext);
+  const sidebarRef = React.useRef<HTMLDivElement>(null);
   const [documents, setDocuments] = useState<ChatInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -29,6 +41,17 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
       .catch(() => setError('Failed to load documents'));
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
   const handleDocumentClick = async (doc: ChatInfo) => {
     try {
       const { url, fileName } = await downloadFile(doc.chatId);
@@ -42,8 +65,12 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
 
   return (
     <>
-      <ToggleButton onClick={toggle}>☰</ToggleButton>
-      <SidebarContainer $open={isOpen}>
+      <ToggleButton onClick={toggle} $open={isOpen}>☰</ToggleButton>
+      <SidebarContainer ref={sidebarRef} $open={isOpen}>
+        <SidebarHeader>
+          <HeaderIcon src={logo} alt="logo" />
+          <CloseButton onClick={close}>X</CloseButton>
+        </SidebarHeader>
         <FileUpload onFileUploaded={(id, url, name) => {
           onFileReady(id, url, name);
           navigate(`/chat/${id}`);
@@ -54,7 +81,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onFileReady }) => {
         <DocumentList>
           {documents.map(doc => (
             <DocumentItem key={doc.chatId} onClick={() => handleDocumentClick(doc)}>
-              <span>{doc.fileName}</span>
+              <DocumentTitle title={doc.fileName}>{doc.fileName}</DocumentTitle>
               <Timestamp>{new Date(doc.createdAt).toLocaleString()}</Timestamp>
             </DocumentItem>
           ))}


### PR DESCRIPTION
## Summary
- add sidebar header with logo and close button
- collapse sidebar when user uploads a PDF
- support click outside to close
- hide sidebar scrollbar and truncate long document titles
- make upload button fill the sidebar width

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d989b2c08324b025fe852d128ed7