### PR TITLE
Improve CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    # Run CI on pushes to master and any other branch
+    branches: ['master', '**']
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r api/requirements.txt
+          pip install -e api
+      - name: Run backend tests
+        working-directory: api
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        working-directory: client
+        run: npm ci
+      - name: Run frontend tests
+        working-directory: client
+        env:
+          CI: true
+          REACT_APP_API_URL: http://127.0.0.1:8000
+        run: npm test -- --watchAll=false

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -33,7 +33,6 @@ decorator==5.2.1
 defusedxml==0.7.1
 Deprecated==1.2.18
 distro==1.9.0
--e git+ssh://git@github.com/patrickamsler/doc-chat.git@e6976c323611fb2ef5f049eda658a31ebcf81a0a#egg=doc_chat&subdirectory=api
 dotenv==0.9.9
 durationpy==0.9
 executing==2.2.0


### PR DESCRIPTION
## Summary
- trigger CI for pushes to master and all branches
- keep running backend `pytest` and frontend `npm test`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846d9f94078832491ec6046fce43da2