### PR TITLE
Add PdfViewer component unit test

### DIFF
--- a/client/src/components/PdfViewer/PdfViewer.test.tsx
+++ b/client/src/components/PdfViewer/PdfViewer.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import PdfViewer from './PdfViewer';
+import { theme } from '../../theme';
+import { PageNavigationPlugin } from '@react-pdf-viewer/page-navigation';
+
+const createMockPlugin = (): PageNavigationPlugin => ({
+  CurrentPageInput: () => <input data-testid="current-page-input" />,
+  NumberOfPages: () => <span data-testid="number-of-pages">1</span>,
+  GoToNextPageButton: () => <button data-testid="next-page">Next</button>,
+  GoToPreviousPageButton: () => <button data-testid="prev-page">Prev</button>,
+} as unknown as PageNavigationPlugin);
+
+beforeAll(() => {
+  // @react-pdf-viewer relies on these observers which are not provided by JSDOM
+  class IntersectionObserverMock {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+  }
+  // @ts-ignore
+  global.IntersectionObserver = IntersectionObserverMock;
+});
+
+describe('PdfViewer', () => {
+  it('renders file name and navigation controls', () => {
+    const plugin = createMockPlugin();
+    render(
+      <ThemeProvider theme={theme}>
+        <PdfViewer fileUrl="dummy.pdf" fileName="Dummy" pageNavigationPluginInstance={plugin} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('Dummy')).toBeInTheDocument();
+    expect(screen.getByTestId('current-page-input')).toBeInTheDocument();
+    expect(screen.getByTestId('number-of-pages')).toBeInTheDocument();
+    expect(screen.getByTestId('next-page')).toBeInTheDocument();
+    expect(screen.getByTestId('prev-page')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create a new unit test for PdfViewer
- provide mock PageNavigationPlugin and IntersectionObserver

## Testing
- `npm test -- --watchAll=false`
- `pytest` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846fb2a7874832486a976fc5698d801